### PR TITLE
Fix sonnet 4.5 sampling params

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,7 @@ Most likely thing to go wrong is not being able to find the credentials, either 
 - Adds headers (Authorization plus a couple specified in config.txt) to trick the endpoint into thinking the request is coming from a real Claude Code application.
 - Remove "ttl" key from any "cache_control" objects, since endpoint does not allow it
 - The first section of the system prompt must be "You are Claude Code, Anthropic's official CLI for Claude." or the request will not be accepted by Anthropic (specifically/technically, it must be the first item of the "system" array's "text" content). I am adding this, but this is just FYI so you know it's there and that you have to deal with it.
+- Optionally filter sampling parameters to avoid conflicts with Sonnet 4.5. Set `filter_sampling_params=true` in `server/config.txt` to enable this feature, which ensures only one sampling parameter is sent to the API. When both `temperature` and `top_p` are specified, it removes whichever is at the default value (1.0), or prefers temperature if both are non-default (Sonnet 4.5 doesn't allow both parameters). Other models work fine with both parameters, so this defaults to off.
 
 ## Todo
 - Implement intelligent caching to deal with SillyTavern features

--- a/server/config.txt
+++ b/server/config.txt
@@ -1,4 +1,4 @@
 port=42069
 host=0.0.0.0
 log_level=INFO  # TRACE, DEBUG, INFO, WARN, ERROR
-filter_sampling_params=true  # Remove top_p=1.0 and prefer temperature over top_p for Sonnet 4.5 compatibility
+filter_sampling_params=false  # Set to true to ensure only one sampling parameter is sent (required for Sonnet 4.5 compatibility). Removes default values (1.0) and prefers temperature over top_p when both are non-default.

--- a/server/config.txt
+++ b/server/config.txt
@@ -1,3 +1,4 @@
 port=42069
 host=0.0.0.0
 log_level=INFO  # TRACE, DEBUG, INFO, WARN, ERROR
+filter_sampling_params=true  # Remove top_p=1.0 and prefer temperature over top_p for Sonnet 4.5 compatibility


### PR DESCRIPTION
# Issue

Claude-Sonnet-4-5 doesn't accept requests with **both** temperature and top_p specified. You must send only 1, but not both. We need a solution that strips top_p, or temperature in a variety of scenarios so only one gets sent. The logic needs to be configurable and default to off since all other Anthropic models are able to receive both sampling parameters.

# Solution

Modified ClaudeRequest.js with logic for handling temperature and top_p stripping in a new function that is controlled by a filter_sampling_params variable in config.txt. Includes updated README.md to explain the new config parameter and what it does.