### PR TITLE
Oauth implementation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,16 @@
 # Node.js dependencies
 server/node_modules/
 server/package-lock.json
+node_modules/
+package-lock.json
+
+# Test files
+server/.test-tokens/
+server/.test-tokens-integration/
+coverage/
+
+# OAuth tokens
+.claude-code-proxy/
 
 # No token cache needed - reading directly from credentials
 
@@ -16,3 +26,5 @@ Thumbs.db
 
 # Logs
 *.log
+
+.claude

--- a/README.md
+++ b/README.md
@@ -9,25 +9,75 @@ There seems to be no safety injection and it gives us full control of the entire
 
 Obviously this is probably not super cool in terms of ToS. But I'm not worried, historically they don't ban web subscribers unless there's VPN/location/sus email/payment shenanigans (as opposed to API which does get got occasionally).
 
-NOTE: this assumes you installed Claude Code in WSL on windows. They've made it installable in regular Windows, but it's still buggy. I guess I'll add support for that eventually, but it's not available yet. I'll happily take a PR =).
+**NEW:** This proxy now has **standalone OAuth authentication**! You no longer need to install Claude Code - just authenticate through your browser. Claude Code credentials are still supported as an optional fallback.
 
 ## Quick Start
-Requires: 
-- nvm, node (installed with nvm), Claude Code, logged in with "Claude account with subscription"
-1. `git clone https://github.com/horselock/claude-code-proxy.git`
-2. `run.sh` or `run.bat` depending on your OS; default port is 42069
 
-- NOT an OpenAI compatible proxy, uses Anthropic's schema 
+### Option 1: Standalone OAuth (Recommended - No Claude Code needed!)
+Requires:
+- Node.js (installed with nvm recommended)
+- Claude MAX subscription
+
+1. `git clone https://github.com/horselock/claude-code-proxy.git`
+2. `npm install` (first time only, to install test dependencies)
+3. `run.sh` or `run.bat` depending on your OS; default port is 42069
+4. Browser will open automatically - authenticate with your Claude account
+5. Done! The proxy is now authenticated and ready to use
+
+### Option 2: Using Claude Code Credentials (Legacy)
+If you already have Claude Code installed and prefer to use its credentials:
+- The proxy will automatically fall back to Claude Code credentials if no OAuth tokens are found
+- Set `fallback_to_claude_code=true` in `server/config.txt` (default)
+
+### Docker startup
+1. `docker-compose up`
+2. Visit `http://localhost:42069/auth/login` to authenticate
+
+**Important Notes:**
+- NOT an OpenAI compatible proxy, uses Anthropic's schema
 - Only exact dated model names of Sonnet 4, 3.7, 3.6, and Haiku 3.5 are allowed. Opus 4 too with Max.
 - Understand your front end's caching, some FEs like ST disable by default, complex RP setups may consistently miss cache and increase costs
 
-### Docker startup
-1. `docker-compose up` (Windows must enter this from wsl, with docker open obviously)
+## Authentication
+
+### OAuth Authentication (Standalone)
+
+The proxy now supports **standalone OAuth authentication** - no Claude Code installation required! When you start the server:
+
+1. If not authenticated, your browser will automatically open to `/auth/login`
+2. You'll be redirected to claude.ai to authorize the application
+3. After approval, tokens are saved to `~/.claude-code-proxy/tokens.json`
+4. Tokens refresh automatically when they expire
+
+**Manual Authentication:**
+- Visit `http://localhost:42069/auth/login` to authenticate
+- Check status: `http://localhost:42069/auth/status`
+- Logout: `http://localhost:42069/auth/logout`
+
+**Configuration Options** (in `server/config.txt`):
+```
+auto_open_browser=true           # Automatically open browser on first run
+fallback_to_claude_code=true     # Use Claude Code credentials as fallback
+host=                            # Leave blank for auto-detect (127.0.0.1 native, 0.0.0.0 Docker)
+```
+
+**Token Priority:**
+1. `x-api-key` header (if provided in requests)
+2. OAuth tokens from `~/.claude-code-proxy/tokens.json`
+3. Claude Code credentials from `~/.claude/.credentials.json` (if fallback enabled)
+
+### Claude Code Credentials (Legacy Fallback)
+
+If you have Claude Code installed, the proxy can use its credentials as a fallback:
+- Automatically used if OAuth tokens don't exist and `fallback_to_claude_code=true`
+- Requires Claude Code to be installed and logged in
+- See the "Beginner/Thorough Guide" section below for Claude Code setup instructions
 
 ## Beginner/Thorough Guide
-As you can see by the Quick Start, like 95% of the setup is making sure you have Claude Code and your local front end are set up right. This utility's setup by itself is pretty much "run the server and point your front end at it." 
 
-This guide assumes windows (untested on Linux but should work fine, there's a section regarding mac at bottom), and no wsl/nvm/node already installed. Just skip any sections you already have done.
+**Note:** With the new OAuth authentication, you may skip the Claude Code installation steps entirely! This guide is kept for users who prefer the Claude Code fallback method.
+
+This guide assumes windows (untested on Linux but should work fine), and no wsl/nvm/node already installed. Just skip any sections you already have done.
 
 ### Install Claude Code 
 
@@ -78,29 +128,57 @@ You're done!
   - What all those warnings mean is that for cache to be used, the convo history up to a certain point has to be the exact same. ST has a lot of advanced features where it makes changes to the start of the context, ruining your savings. But for simpler use cases, it's fine. Set the context to 200K IMO - as stuff falls out of context if you choose a lower number, that changes the convo start 
 
 ### Troubleshooting
+
+#### OAuth Authentication Issues
+- **Browser doesn't open automatically**: Visit `http://localhost:42069/auth/login` manually
+- **Authentication fails**: Make sure you're logged into claude.ai in your browser
+- **Tokens expire**: They refresh automatically, but if you see auth errors, try logging out and in again
+- **Check authentication status**: Visit `http://localhost:42069/auth/status`
+
+#### Claude Code Fallback Issues (Legacy)
 Most likely thing to go wrong is not being able to find the credentials, either due to permissions or location.
 - Ensure you installed node in wsl with nvm, if not, just redo it.
 - Make sure your wsl default is Ubuntu (the default distro that comes with wsl)
-- If all else fails, go to wsl, `cat ~/.claude/.credentials.json`, copy out the access token (after sending a message from Claude Code first to make sure it's not expired), and put it in the authentication header. In ST, this is the Proxy "password". 
+- If all else fails, go to wsl, `cat ~/.claude/.credentials.json`, copy out the access token (after sending a message from Claude Code first to make sure it's not expired), and put it in the authentication header. In ST, this is the Proxy "password".
   - If that's one too steps, you can go to util folder, enter wsl in the address bar, and run `claude-bearer.js` - that'll make sure it's not expired, and you'll get the token delivered to you. You don't have to copy "Bearer"
-- If you tend to leave Claude Code open for hours, you may find yourself logged out. This means the access token expired and this proxy renewed it, but  Claude Code just sits there upset that it's expired instead of just checking the file. Just close Claude Code, it'll be fine when you open it again.
+- If you tend to leave Claude Code open for hours, you may find yourself logged out. This means the access token expired and this proxy renewed it, but Claude Code just sits there upset that it's expired instead of just checking the file. Just close Claude Code, it'll be fine when you open it again.
 
 ## What This Does
-- Adds headers (Authorization plus a couple specified in config.txt) to trick the endpoint into thinking the request is coming from a real Claude Code application.
+
+### Authentication
+- **OAuth Flow**: Implements PKCE OAuth 2.0 flow to authenticate directly with claude.ai
+- **Token Management**: Automatically refreshes access tokens when they expire
+- **Fallback Support**: Can optionally use Claude Code credentials as a fallback
+
+### Request Processing
+- Adds headers (Authorization plus a couple specified in config.txt) to trick the endpoint into thinking the request is coming from a real Claude Code application
 - Remove "ttl" key from any "cache_control" objects, since endpoint does not allow it
-- The first section of the system prompt must be "You are Claude Code, Anthropic's official CLI for Claude." or the request will not be accepted by Anthropic (specifically/technically, it must be the first item of the "system" array's "text" content). I am adding this, but this is just FYI so you know it's there and that you have to deal with it.
-- Optionally filter sampling parameters to avoid conflicts with Sonnet 4.5. Set `filter_sampling_params=true` in `server/config.txt` to enable this feature, which ensures only one sampling parameter is sent to the API. When both `temperature` and `top_p` are specified, it removes whichever is at the default value (1.0), or prefers temperature if both are non-default (Sonnet 4.5 doesn't allow both parameters). Other models work fine with both parameters, so this defaults to off.
+- The first section of the system prompt must be "You are Claude Code, Anthropic's official CLI for Claude." or the request will not be accepted by Anthropic (specifically/technically, it must be the first item of the "system" array's "text" content). I am adding this, but this is just FYI so you know it's there and that you have to deal with it
+- Optionally filter sampling parameters to avoid conflicts with Sonnet 4.5. Set `filter_sampling_params=true` in `server/config.txt` to enable this feature, which ensures only one sampling parameter is sent to the API. When both `temperature` and `top_p` are specified, it removes whichever is at the default value (1.0), or prefers temperature if both are non-default (Sonnet 4.5 doesn't allow both parameters). Other models work fine with both parameters, so this defaults to off
+
+### Smart Host Binding
+- **Native execution**: Binds to `127.0.0.1` (secure, local-only)
+- **Docker container**: Automatically detects and binds to `0.0.0.0` (required for port mapping)
+- **Manual override**: Set explicit `host=` value in config.txt to override auto-detection
 
 ## Mac
-A user had this to say:
-Finally got around to trying this. Posting this in case it helps any other Mac users.
-On my Macbook, there is no ~/.claude/credentials.json file for the server to parse. On my Mac, I found the token was securely stored in the Keychain Access app, not insecurely as a plain text file! So:
-I opened Keychain Access and searched for "Claude" which revealed the "Claude Code-credentials" entry
-Double click to open the entry > click "Show password" to reveal the token string (Authenticate with your password if asked)
-Copy the text of the token (which is the json content needed)
-Using your text editor of choice, create the file ~/.claude/credentials.json and paste the token text in and save
-Now when you access the proxy, it can parse the ~/.claude/credentials.json file and extract what it needs to spoof the bearer token to grant access to Claude nirvana!
+
+**Good news for Mac users!** With the new OAuth authentication, you no longer need to extract credentials from Keychain Access. Just use the standalone OAuth flow:
+
+1. Start the server with `./run.sh`
+2. Authenticate through your browser when it opens
+3. Done!
+
+### Legacy: Claude Code Credentials on Mac (Optional)
+If you prefer to use Claude Code credentials as a fallback:
+
+On Mac, Claude Code stores credentials securely in the Keychain Access app rather than as a plain text file. To extract them:
+1. Open Keychain Access and search for "Claude" (reveals "Claude Code-credentials" entry)
+2. Double click to open the entry > click "Show password" (authenticate with your password if asked)
+3. Copy the text of the token (the json content)
+4. Using your text editor of choice, create the file `~/.claude/credentials.json` and paste the token text in and save
+5. Now when you access the proxy, it can parse the `~/.claude/credentials.json` file and extract what it needs
 
 ## Todo
 - Implement intelligent caching to deal with SillyTavern features
-- Possibly auto-refreshing creds with CLI option
+- ~~Possibly auto-refreshing creds with CLI option~~ ✓ **Done! OAuth tokens refresh automatically**

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,11 +2,13 @@ services:
   claude-proxy:
     image: node:22-alpine
     working_dir: /app
-    command: node server/server.js
+    command: sh -c "npm install --only=production 2>/dev/null || true && node server/server.js"
     ports:
       - "42069:42069"
     volumes:
       - ~/.claude:/root/.claude
-      - ./server:/app/server
-      - ./util:/app/util
+      - ~/.claude-code-proxy:/root/.claude-code-proxy
+      - .:/app
+    environment:
+      - NODE_ENV=production
 

--- a/package.json
+++ b/package.json
@@ -1,0 +1,37 @@
+{
+  "name": "claude-code-proxy",
+  "version": "1.0.0",
+  "description": "A proxy server for Claude Code API with standalone OAuth authentication",
+  "main": "server/server.js",
+  "scripts": {
+    "start": "node server/server.js",
+    "test": "jest",
+    "test:watch": "jest --watch",
+    "test:coverage": "jest --coverage"
+  },
+  "keywords": [
+    "claude",
+    "anthropic",
+    "proxy",
+    "oauth"
+  ],
+  "author": "",
+  "license": "MIT",
+  "devDependencies": {
+    "jest": "^29.7.0",
+    "supertest": "^6.3.4",
+    "nock": "^13.5.0"
+  },
+  "jest": {
+    "testEnvironment": "node",
+    "coverageDirectory": "coverage",
+    "collectCoverageFrom": [
+      "server/**/*.js",
+      "!server/**/*.test.js"
+    ],
+    "testMatch": [
+      "**/__tests__/**/*.js",
+      "**/?(*.)+(spec|test).js"
+    ]
+  }
+}

--- a/server/ClaudeRequest.js
+++ b/server/ClaudeRequest.js
@@ -38,7 +38,7 @@ const loadConfig = () => {
 
 const CONFIG = loadConfig();
 const FILTER_SAMPLING_PARAMS = CONFIG.filter_sampling_params === true; // Default to false
-const FALLBACK_TO_CLAUDE_CODE = CONFIG.fallback_to_claude_code !== 'false'; // Default to true
+const FALLBACK_TO_CLAUDE_CODE = CONFIG.fallback_to_claude_code !== false; // Default to true
 
 class ClaudeRequest {
   static cachedToken = null;

--- a/server/OAuthManager.js
+++ b/server/OAuthManager.js
@@ -1,0 +1,307 @@
+const crypto = require('crypto');
+const fs = require('fs');
+const path = require('path');
+const https = require('https');
+const Logger = require('./Logger');
+
+const OAUTH_CONFIG = {
+  client_id: '9d1c250a-e61b-44d9-88ed-5944d1962f5e',
+  authorize_url: 'https://claude.ai/oauth/authorize',
+  token_url: 'https://console.anthropic.com/v1/oauth/token',
+  redirect_uri: null, // Will be set dynamically based on server host/port
+  scope: 'org:create_api_key user:profile user:inference'
+};
+
+class OAuthManager {
+  constructor() {
+    this.tokenPath = path.join(
+      process.env.HOME || process.env.USERPROFILE,
+      '.claude-code-proxy',
+      'tokens.json'
+    );
+    this.cachedToken = null;
+    this.refreshPromise = null;
+  }
+
+  /**
+   * Generate PKCE code verifier, challenge, and state for OAuth flow
+   * @returns {{code_verifier: string, code_challenge: string, state: string}}
+   */
+  generatePKCE() {
+    // Generate random code verifier (43-128 chars)
+    const code_verifier = crypto.randomBytes(32).toString('base64url');
+
+    // Generate code challenge using S256 method
+    const code_challenge = crypto
+      .createHash('sha256')
+      .update(code_verifier)
+      .digest('base64url');
+
+    // Generate random state for CSRF protection
+    const state = crypto.randomBytes(16).toString('base64url');
+
+    return { code_verifier, code_challenge, state };
+  }
+
+  /**
+   * Build authorization URL for user to visit
+   * @param {{code_challenge: string, state: string}} pkce
+   * @returns {string} Authorization URL
+   */
+  buildAuthorizationURL(pkce) {
+    const params = new URLSearchParams({
+      client_id: OAUTH_CONFIG.client_id,
+      response_type: 'code',
+      redirect_uri: OAUTH_CONFIG.redirect_uri,
+      scope: OAUTH_CONFIG.scope,
+      code_challenge: pkce.code_challenge,
+      code_challenge_method: 'S256',
+      state: pkce.state
+    });
+
+    return `${OAUTH_CONFIG.authorize_url}?${params.toString()}`;
+  }
+
+  /**
+   * Exchange authorization code for access and refresh tokens
+   * @param {string} code - Authorization code from callback
+   * @param {string} code_verifier - PKCE code verifier
+   * @returns {Promise<{access_token: string, refresh_token: string, expires_in: number}>}
+   */
+  async exchangeCodeForTokens(code, code_verifier) {
+    const payload = JSON.stringify({
+      grant_type: 'authorization_code',
+      code: code,
+      client_id: OAUTH_CONFIG.client_id,
+      code_verifier: code_verifier,
+      redirect_uri: OAUTH_CONFIG.redirect_uri
+    });
+
+    try {
+      const response = await this._makeTokenRequest(payload);
+      Logger.info('Successfully exchanged authorization code for tokens');
+      return response;
+    } catch (error) {
+      Logger.error('Failed to exchange code for tokens', error);
+      throw error;
+    }
+  }
+
+  /**
+   * Refresh the access token using the refresh token
+   * @returns {Promise<{access_token: string, refresh_token: string, expires_in: number}>}
+   */
+  async refreshAccessToken() {
+    // Prevent race conditions with concurrent refresh attempts
+    if (this.refreshPromise) {
+      Logger.debug('Token refresh already in progress, waiting...');
+      return this.refreshPromise;
+    }
+
+    this.refreshPromise = (async () => {
+      try {
+        const tokens = this.loadTokens();
+        if (!tokens || !tokens.refresh_token) {
+          throw new Error('No refresh token available');
+        }
+
+        const payload = JSON.stringify({
+          grant_type: 'refresh_token',
+          refresh_token: tokens.refresh_token,
+          client_id: OAUTH_CONFIG.client_id
+        });
+
+        const response = await this._makeTokenRequest(payload);
+        Logger.info('Successfully refreshed access token');
+
+        // Save new tokens
+        const newTokens = {
+          access_token: response.access_token,
+          refresh_token: response.refresh_token || tokens.refresh_token,
+          expires_at: Date.now() + (response.expires_in * 1000)
+        };
+        this.saveTokens(newTokens);
+        this.cachedToken = newTokens.access_token;
+
+        return response;
+      } finally {
+        this.refreshPromise = null;
+      }
+    })();
+
+    return this.refreshPromise;
+  }
+
+  /**
+   * Make an HTTPS request to the token endpoint
+   * @param {string} payload - JSON payload to send
+   * @returns {Promise<Object>} Token response
+   * @private
+   */
+  _makeTokenRequest(payload) {
+    return new Promise((resolve, reject) => {
+      const url = new URL(OAUTH_CONFIG.token_url);
+
+      const options = {
+        hostname: url.hostname,
+        port: url.port || 443,
+        path: url.pathname,
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          'Content-Length': Buffer.byteLength(payload)
+        }
+      };
+
+      const req = https.request(options, (res) => {
+        let data = '';
+
+        res.on('data', (chunk) => {
+          data += chunk;
+        });
+
+        res.on('end', () => {
+          if (res.statusCode >= 200 && res.statusCode < 300) {
+            try {
+              resolve(JSON.parse(data));
+            } catch (error) {
+              reject(new Error(`Failed to parse token response: ${error.message}`));
+            }
+          } else {
+            reject(new Error(`Token request failed with status ${res.statusCode}: ${data}`));
+          }
+        });
+      });
+
+      req.on('error', (error) => {
+        reject(error);
+      });
+
+      req.write(payload);
+      req.end();
+    });
+  }
+
+  /**
+   * Load tokens from local file
+   * @returns {Object|null} Tokens object or null if not found
+   */
+  loadTokens() {
+    try {
+      if (!fs.existsSync(this.tokenPath)) {
+        return null;
+      }
+
+      const data = fs.readFileSync(this.tokenPath, 'utf8');
+      return JSON.parse(data);
+    } catch (error) {
+      Logger.error('Failed to load tokens from file', error);
+      return null;
+    }
+  }
+
+  /**
+   * Save tokens to local file
+   * @param {{access_token: string, refresh_token: string, expires_at: number}} tokens
+   */
+  saveTokens(tokens) {
+    try {
+      // Ensure directory exists
+      const dir = path.dirname(this.tokenPath);
+      if (!fs.existsSync(dir)) {
+        fs.mkdirSync(dir, { recursive: true });
+      }
+
+      fs.writeFileSync(this.tokenPath, JSON.stringify(tokens, null, 2), 'utf8');
+
+      // Set file permissions to 600 (owner read/write only) on Unix
+      if (process.platform !== 'win32') {
+        fs.chmodSync(this.tokenPath, 0o600);
+      }
+
+      Logger.info('Tokens saved successfully');
+    } catch (error) {
+      Logger.error('Failed to save tokens to file', error);
+      throw error;
+    }
+  }
+
+  /**
+   * Get a valid access token, refreshing if necessary
+   * @returns {Promise<string>} Valid access token
+   */
+  async getValidAccessToken() {
+    // Use cached token if available
+    if (this.cachedToken) {
+      const tokens = this.loadTokens();
+      if (tokens && tokens.expires_at > Date.now() + 60000) { // 1 minute buffer
+        return this.cachedToken;
+      }
+    }
+
+    const tokens = this.loadTokens();
+    if (!tokens) {
+      throw new Error('No authentication tokens found. Please authenticate first.');
+    }
+
+    // Check if token is expired or expiring soon (1 minute buffer)
+    if (tokens.expires_at <= Date.now() + 60000) {
+      Logger.info('Access token expired or expiring soon, refreshing...');
+      await this.refreshAccessToken();
+      const newTokens = this.loadTokens();
+      this.cachedToken = newTokens.access_token;
+      return this.cachedToken;
+    }
+
+    this.cachedToken = tokens.access_token;
+    return tokens.access_token;
+  }
+
+  /**
+   * Check if user is authenticated (has valid tokens)
+   * @returns {boolean} True if authenticated
+   */
+  isAuthenticated() {
+    const tokens = this.loadTokens();
+    return !!(tokens && tokens.access_token && tokens.refresh_token);
+  }
+
+  /**
+   * Get token expiration time
+   * @returns {Date|null} Expiration date or null if not authenticated
+   */
+  getTokenExpiration() {
+    const tokens = this.loadTokens();
+    if (!tokens || !tokens.expires_at) {
+      return null;
+    }
+    return new Date(tokens.expires_at);
+  }
+
+  /**
+   * Delete stored tokens (logout)
+   */
+  logout() {
+    try {
+      if (fs.existsSync(this.tokenPath)) {
+        fs.unlinkSync(this.tokenPath);
+        Logger.info('Tokens deleted successfully');
+      }
+      this.cachedToken = null;
+    } catch (error) {
+      Logger.error('Failed to delete tokens', error);
+      throw error;
+    }
+  }
+
+  /**
+   * Set the redirect URI (called by server on startup)
+   * @param {string} uri - Redirect URI
+   */
+  setRedirectURI(uri) {
+    OAUTH_CONFIG.redirect_uri = uri;
+  }
+}
+
+// Export singleton instance
+module.exports = new OAuthManager();

--- a/server/OAuthManager.js
+++ b/server/OAuthManager.js
@@ -8,7 +8,7 @@ const OAUTH_CONFIG = {
   client_id: '9d1c250a-e61b-44d9-88ed-5944d1962f5e',
   authorize_url: 'https://claude.ai/oauth/authorize',
   token_url: 'https://console.anthropic.com/v1/oauth/token',
-  redirect_uri_manual: 'https://console.anthropic.com/oauth/code/callback', // Anthropic's callback page (shows code to user)
+  redirect_uri: 'https://console.anthropic.com/oauth/code/callback', // Anthropic's callback page (shows code to user)
   scope: 'org:create_api_key user:profile user:inference'
 };
 
@@ -21,28 +21,6 @@ class OAuthManager {
     );
     this.cachedToken = null;
     this.refreshPromise = null;
-    this.redirectUri = OAUTH_CONFIG.redirect_uri_manual; // Default to manual flow
-  }
-
-  /**
-   * Set the redirect URI for OAuth flow
-   * @param {string} uri - The redirect URI (use 'manual' for Anthropic's callback page)
-   */
-  setRedirectURI(uri) {
-    if (uri === 'manual') {
-      this.redirectUri = OAUTH_CONFIG.redirect_uri_manual;
-    } else {
-      this.redirectUri = uri;
-    }
-    Logger.debug(`OAuth redirect URI set to: ${this.redirectUri}`);
-  }
-
-  /**
-   * Get the current redirect URI
-   * @returns {string} The current redirect URI
-   */
-  getRedirectURI() {
-    return this.redirectUri;
   }
 
   /**
@@ -75,7 +53,7 @@ class OAuthManager {
       code: 'true', // Required: tells Anthropic to display the authorization code
       client_id: OAUTH_CONFIG.client_id,
       response_type: 'code',
-      redirect_uri: this.redirectUri,
+      redirect_uri: OAUTH_CONFIG.redirect_uri,
       scope: OAUTH_CONFIG.scope,
       code_challenge: pkce.code_challenge,
       code_challenge_method: 'S256',
@@ -99,7 +77,7 @@ class OAuthManager {
       state: state,
       client_id: OAUTH_CONFIG.client_id,
       code_verifier: code_verifier,
-      redirect_uri: this.redirectUri
+      redirect_uri: OAUTH_CONFIG.redirect_uri
     });
 
     try {

--- a/server/OAuthManager.js
+++ b/server/OAuthManager.js
@@ -8,7 +8,7 @@ const OAUTH_CONFIG = {
   client_id: '9d1c250a-e61b-44d9-88ed-5944d1962f5e',
   authorize_url: 'https://claude.ai/oauth/authorize',
   token_url: 'https://console.anthropic.com/v1/oauth/token',
-  redirect_uri: 'https://console.anthropic.com/oauth/code/callback', // Anthropic's callback page (shows code to user)
+  redirect_uri_manual: 'https://console.anthropic.com/oauth/code/callback', // Anthropic's callback page (shows code to user)
   scope: 'org:create_api_key user:profile user:inference'
 };
 
@@ -21,6 +21,28 @@ class OAuthManager {
     );
     this.cachedToken = null;
     this.refreshPromise = null;
+    this.redirectUri = OAUTH_CONFIG.redirect_uri_manual; // Default to manual flow
+  }
+
+  /**
+   * Set the redirect URI for OAuth flow
+   * @param {string} uri - The redirect URI (use 'manual' for Anthropic's callback page)
+   */
+  setRedirectURI(uri) {
+    if (uri === 'manual') {
+      this.redirectUri = OAUTH_CONFIG.redirect_uri_manual;
+    } else {
+      this.redirectUri = uri;
+    }
+    Logger.debug(`OAuth redirect URI set to: ${this.redirectUri}`);
+  }
+
+  /**
+   * Get the current redirect URI
+   * @returns {string} The current redirect URI
+   */
+  getRedirectURI() {
+    return this.redirectUri;
   }
 
   /**
@@ -53,7 +75,7 @@ class OAuthManager {
       code: 'true', // Required: tells Anthropic to display the authorization code
       client_id: OAUTH_CONFIG.client_id,
       response_type: 'code',
-      redirect_uri: OAUTH_CONFIG.redirect_uri,
+      redirect_uri: this.redirectUri,
       scope: OAUTH_CONFIG.scope,
       code_challenge: pkce.code_challenge,
       code_challenge_method: 'S256',
@@ -77,7 +99,7 @@ class OAuthManager {
       state: state,
       client_id: OAUTH_CONFIG.client_id,
       code_verifier: code_verifier,
-      redirect_uri: OAUTH_CONFIG.redirect_uri
+      redirect_uri: this.redirectUri
     });
 
     try {

--- a/server/OAuthManager.js
+++ b/server/OAuthManager.js
@@ -8,7 +8,7 @@ const OAUTH_CONFIG = {
   client_id: '9d1c250a-e61b-44d9-88ed-5944d1962f5e',
   authorize_url: 'https://claude.ai/oauth/authorize',
   token_url: 'https://console.anthropic.com/v1/oauth/token',
-  redirect_uri: null, // Will be set dynamically based on server host/port
+  redirect_uri: 'https://console.anthropic.com/oauth/code/callback', // Anthropic's callback page (shows code to user)
   scope: 'org:create_api_key user:profile user:inference'
 };
 
@@ -294,13 +294,6 @@ class OAuthManager {
     }
   }
 
-  /**
-   * Set the redirect URI (called by server on startup)
-   * @param {string} uri - Redirect URI
-   */
-  setRedirectURI(uri) {
-    OAUTH_CONFIG.redirect_uri = uri;
-  }
 }
 
 // Export singleton instance

--- a/server/OAuthManager.test.js
+++ b/server/OAuthManager.test.js
@@ -27,9 +27,6 @@ describe('OAuthManager', () => {
     if (fs.existsSync(testDir)) {
       fs.rmSync(testDir, { recursive: true, force: true });
     }
-
-    // Set redirect URI for tests
-    OAuthManager.setRedirectURI('http://localhost:42069/auth/callback');
   });
 
   afterEach(() => {
@@ -95,7 +92,7 @@ describe('OAuthManager', () => {
       expect(url).toContain('code_challenge_method=S256');
       expect(url).toContain('state=test-state');
       expect(url).toContain('scope=org%3Acreate_api_key+user%3Aprofile+user%3Ainference');
-      expect(url).toContain('redirect_uri=http%3A%2F%2Flocalhost%3A42069%2Fauth%2Fcallback');
+      expect(url).toContain('redirect_uri=https%3A%2F%2Fconsole.anthropic.com%2Foauth%2Fcode%2Fcallback');
     });
   });
 
@@ -252,7 +249,7 @@ describe('OAuthManager', () => {
           state: 'test-state',
           client_id: '9d1c250a-e61b-44d9-88ed-5944d1962f5e',
           code_verifier: 'test-code-verifier',
-          redirect_uri: 'http://localhost:42069/auth/callback'
+          redirect_uri: 'https://console.anthropic.com/oauth/code/callback'
         })
         .reply(200, mockResponse);
 
@@ -408,14 +405,4 @@ describe('OAuthManager', () => {
     });
   });
 
-  describe('setRedirectURI', () => {
-    it('should set redirect URI', () => {
-      OAuthManager.setRedirectURI('http://example.com/callback');
-
-      const pkce = OAuthManager.generatePKCE();
-      const url = OAuthManager.buildAuthorizationURL(pkce);
-
-      expect(url).toContain('redirect_uri=http%3A%2F%2Fexample.com%2Fcallback');
-    });
-  });
 });

--- a/server/OAuthManager.test.js
+++ b/server/OAuthManager.test.js
@@ -249,13 +249,14 @@ describe('OAuthManager', () => {
         .post('/v1/oauth/token', {
           grant_type: 'authorization_code',
           code: 'test-auth-code',
+          state: 'test-state',
           client_id: '9d1c250a-e61b-44d9-88ed-5944d1962f5e',
           code_verifier: 'test-code-verifier',
           redirect_uri: 'http://localhost:42069/auth/callback'
         })
         .reply(200, mockResponse);
 
-      const tokens = await OAuthManager.exchangeCodeForTokens('test-auth-code', 'test-code-verifier');
+      const tokens = await OAuthManager.exchangeCodeForTokens('test-auth-code', 'test-code-verifier', 'test-state');
 
       expect(tokens).toEqual(mockResponse);
     });
@@ -266,7 +267,7 @@ describe('OAuthManager', () => {
         .reply(400, { error: 'invalid_grant' });
 
       await expect(
-        OAuthManager.exchangeCodeForTokens('invalid-code', 'test-verifier')
+        OAuthManager.exchangeCodeForTokens('invalid-code', 'test-verifier', 'test-state')
       ).rejects.toThrow();
     });
   });

--- a/server/OAuthManager.test.js
+++ b/server/OAuthManager.test.js
@@ -1,0 +1,420 @@
+const fs = require('fs');
+const path = require('path');
+const crypto = require('crypto');
+const nock = require('nock');
+const OAuthManager = require('./OAuthManager');
+
+// Mock the Logger module
+jest.mock('./Logger', () => ({
+  info: jest.fn(),
+  debug: jest.fn(),
+  error: jest.fn(),
+  warn: jest.fn()
+}));
+
+describe('OAuthManager', () => {
+  let testTokenPath;
+
+  beforeEach(() => {
+    // Use a temporary directory for testing
+    testTokenPath = path.join(__dirname, '.test-tokens', 'tokens.json');
+    OAuthManager.tokenPath = testTokenPath;
+    OAuthManager.cachedToken = null;
+    OAuthManager.refreshPromise = null;
+
+    // Clean up test directory
+    const testDir = path.dirname(testTokenPath);
+    if (fs.existsSync(testDir)) {
+      fs.rmSync(testDir, { recursive: true, force: true });
+    }
+
+    // Set redirect URI for tests
+    OAuthManager.setRedirectURI('http://localhost:42069/auth/callback');
+  });
+
+  afterEach(() => {
+    // Clean up
+    const testDir = path.dirname(testTokenPath);
+    if (fs.existsSync(testDir)) {
+      fs.rmSync(testDir, { recursive: true, force: true });
+    }
+    nock.cleanAll();
+  });
+
+  describe('generatePKCE', () => {
+    it('should generate valid PKCE parameters', () => {
+      const pkce = OAuthManager.generatePKCE();
+
+      expect(pkce).toHaveProperty('code_verifier');
+      expect(pkce).toHaveProperty('code_challenge');
+      expect(pkce).toHaveProperty('state');
+
+      expect(typeof pkce.code_verifier).toBe('string');
+      expect(typeof pkce.code_challenge).toBe('string');
+      expect(typeof pkce.state).toBe('string');
+
+      expect(pkce.code_verifier.length).toBeGreaterThan(0);
+      expect(pkce.code_challenge.length).toBeGreaterThan(0);
+      expect(pkce.state.length).toBeGreaterThan(0);
+    });
+
+    it('should generate different values on each call', () => {
+      const pkce1 = OAuthManager.generatePKCE();
+      const pkce2 = OAuthManager.generatePKCE();
+
+      expect(pkce1.code_verifier).not.toBe(pkce2.code_verifier);
+      expect(pkce1.code_challenge).not.toBe(pkce2.code_challenge);
+      expect(pkce1.state).not.toBe(pkce2.state);
+    });
+
+    it('should generate code_challenge from code_verifier using SHA256', () => {
+      const pkce = OAuthManager.generatePKCE();
+
+      const expectedChallenge = crypto
+        .createHash('sha256')
+        .update(pkce.code_verifier)
+        .digest('base64url');
+
+      expect(pkce.code_challenge).toBe(expectedChallenge);
+    });
+  });
+
+  describe('buildAuthorizationURL', () => {
+    it('should build valid authorization URL', () => {
+      const pkce = {
+        code_challenge: 'test-challenge',
+        state: 'test-state'
+      };
+
+      const url = OAuthManager.buildAuthorizationURL(pkce);
+
+      expect(url).toContain('https://claude.ai/oauth/authorize');
+      expect(url).toContain('client_id=9d1c250a-e61b-44d9-88ed-5944d1962f5e');
+      expect(url).toContain('response_type=code');
+      expect(url).toContain('code_challenge=test-challenge');
+      expect(url).toContain('code_challenge_method=S256');
+      expect(url).toContain('state=test-state');
+      expect(url).toContain('scope=org%3Acreate_api_key+user%3Aprofile+user%3Ainference');
+      expect(url).toContain('redirect_uri=http%3A%2F%2Flocalhost%3A42069%2Fauth%2Fcallback');
+    });
+  });
+
+  describe('saveTokens and loadTokens', () => {
+    it('should save and load tokens successfully', () => {
+      const tokens = {
+        access_token: 'test-access-token',
+        refresh_token: 'test-refresh-token',
+        expires_at: Date.now() + 3600000
+      };
+
+      OAuthManager.saveTokens(tokens);
+
+      const loaded = OAuthManager.loadTokens();
+      expect(loaded).toEqual(tokens);
+    });
+
+    it('should create directory if it does not exist', () => {
+      const tokens = {
+        access_token: 'test-access-token',
+        refresh_token: 'test-refresh-token',
+        expires_at: Date.now() + 3600000
+      };
+
+      const testDir = path.dirname(testTokenPath);
+      expect(fs.existsSync(testDir)).toBe(false);
+
+      OAuthManager.saveTokens(tokens);
+
+      expect(fs.existsSync(testDir)).toBe(true);
+      expect(fs.existsSync(testTokenPath)).toBe(true);
+    });
+
+    it('should set file permissions to 600 on Unix', () => {
+      if (process.platform === 'win32') {
+        return; // Skip this test on Windows
+      }
+
+      const tokens = {
+        access_token: 'test-access-token',
+        refresh_token: 'test-refresh-token',
+        expires_at: Date.now() + 3600000
+      };
+
+      OAuthManager.saveTokens(tokens);
+
+      const stats = fs.statSync(testTokenPath);
+      const mode = stats.mode & 0o777;
+      expect(mode).toBe(0o600);
+    });
+
+    it('should return null if token file does not exist', () => {
+      const loaded = OAuthManager.loadTokens();
+      expect(loaded).toBeNull();
+    });
+
+    it('should return null if token file is invalid JSON', () => {
+      const testDir = path.dirname(testTokenPath);
+      fs.mkdirSync(testDir, { recursive: true });
+      fs.writeFileSync(testTokenPath, 'invalid json');
+
+      const loaded = OAuthManager.loadTokens();
+      expect(loaded).toBeNull();
+    });
+  });
+
+  describe('isAuthenticated', () => {
+    it('should return false when no tokens exist', () => {
+      expect(OAuthManager.isAuthenticated()).toBe(false);
+    });
+
+    it('should return true when valid tokens exist', () => {
+      const tokens = {
+        access_token: 'test-access-token',
+        refresh_token: 'test-refresh-token',
+        expires_at: Date.now() + 3600000
+      };
+
+      OAuthManager.saveTokens(tokens);
+      expect(OAuthManager.isAuthenticated()).toBe(true);
+    });
+
+    it('should return true even if tokens are expired', () => {
+      // isAuthenticated only checks if tokens exist, not if they're expired
+      const tokens = {
+        access_token: 'test-access-token',
+        refresh_token: 'test-refresh-token',
+        expires_at: Date.now() - 1000
+      };
+
+      OAuthManager.saveTokens(tokens);
+      expect(OAuthManager.isAuthenticated()).toBe(true);
+    });
+  });
+
+  describe('getTokenExpiration', () => {
+    it('should return null when no tokens exist', () => {
+      expect(OAuthManager.getTokenExpiration()).toBeNull();
+    });
+
+    it('should return expiration date when tokens exist', () => {
+      const expiresAt = Date.now() + 3600000;
+      const tokens = {
+        access_token: 'test-access-token',
+        refresh_token: 'test-refresh-token',
+        expires_at: expiresAt
+      };
+
+      OAuthManager.saveTokens(tokens);
+
+      const expiration = OAuthManager.getTokenExpiration();
+      expect(expiration).toBeInstanceOf(Date);
+      expect(expiration.getTime()).toBe(expiresAt);
+    });
+  });
+
+  describe('logout', () => {
+    it('should delete token file and clear cached token', () => {
+      const tokens = {
+        access_token: 'test-access-token',
+        refresh_token: 'test-refresh-token',
+        expires_at: Date.now() + 3600000
+      };
+
+      OAuthManager.saveTokens(tokens);
+      OAuthManager.cachedToken = 'cached-token';
+
+      expect(fs.existsSync(testTokenPath)).toBe(true);
+      expect(OAuthManager.cachedToken).toBe('cached-token');
+
+      OAuthManager.logout();
+
+      expect(fs.existsSync(testTokenPath)).toBe(false);
+      expect(OAuthManager.cachedToken).toBeNull();
+    });
+
+    it('should not throw error if token file does not exist', () => {
+      expect(() => OAuthManager.logout()).not.toThrow();
+    });
+  });
+
+  describe('exchangeCodeForTokens', () => {
+    it('should exchange authorization code for tokens', async () => {
+      const mockResponse = {
+        access_token: 'new-access-token',
+        refresh_token: 'new-refresh-token',
+        expires_in: 3600
+      };
+
+      nock('https://console.anthropic.com')
+        .post('/v1/oauth/token', {
+          grant_type: 'authorization_code',
+          code: 'test-auth-code',
+          client_id: '9d1c250a-e61b-44d9-88ed-5944d1962f5e',
+          code_verifier: 'test-code-verifier',
+          redirect_uri: 'http://localhost:42069/auth/callback'
+        })
+        .reply(200, mockResponse);
+
+      const tokens = await OAuthManager.exchangeCodeForTokens('test-auth-code', 'test-code-verifier');
+
+      expect(tokens).toEqual(mockResponse);
+    });
+
+    it('should throw error on failed token exchange', async () => {
+      nock('https://console.anthropic.com')
+        .post('/v1/oauth/token')
+        .reply(400, { error: 'invalid_grant' });
+
+      await expect(
+        OAuthManager.exchangeCodeForTokens('invalid-code', 'test-verifier')
+      ).rejects.toThrow();
+    });
+  });
+
+  describe('refreshAccessToken', () => {
+    it('should refresh access token successfully', async () => {
+      const oldTokens = {
+        access_token: 'old-access-token',
+        refresh_token: 'test-refresh-token',
+        expires_at: Date.now() - 1000
+      };
+      OAuthManager.saveTokens(oldTokens);
+
+      const mockResponse = {
+        access_token: 'new-access-token',
+        refresh_token: 'new-refresh-token',
+        expires_in: 3600
+      };
+
+      nock('https://console.anthropic.com')
+        .post('/v1/oauth/token', {
+          grant_type: 'refresh_token',
+          refresh_token: 'test-refresh-token',
+          client_id: '9d1c250a-e61b-44d9-88ed-5944d1962f5e'
+        })
+        .reply(200, mockResponse);
+
+      await OAuthManager.refreshAccessToken();
+
+      const updatedTokens = OAuthManager.loadTokens();
+      expect(updatedTokens.access_token).toBe('new-access-token');
+      expect(updatedTokens.refresh_token).toBe('new-refresh-token');
+      expect(updatedTokens.expires_at).toBeGreaterThan(Date.now());
+    });
+
+    it('should prevent concurrent refresh attempts', async () => {
+      const tokens = {
+        access_token: 'old-token',
+        refresh_token: 'test-refresh-token',
+        expires_at: Date.now() - 1000
+      };
+      OAuthManager.saveTokens(tokens);
+
+      const mockResponse = {
+        access_token: 'new-token',
+        refresh_token: 'new-refresh-token',
+        expires_in: 3600
+      };
+
+      let requestCount = 0;
+      nock('https://console.anthropic.com')
+        .post('/v1/oauth/token')
+        .times(2)
+        .reply(200, () => {
+          requestCount++;
+          return mockResponse;
+        });
+
+      // Start two refresh operations concurrently
+      const [result1, result2] = await Promise.all([
+        OAuthManager.refreshAccessToken(),
+        OAuthManager.refreshAccessToken()
+      ]);
+
+      // Both should succeed but only one request should be made
+      expect(result1).toEqual(mockResponse);
+      expect(result2).toEqual(mockResponse);
+      expect(requestCount).toBe(1);
+    });
+
+    it('should throw error if no refresh token available', async () => {
+      await expect(OAuthManager.refreshAccessToken()).rejects.toThrow('No refresh token available');
+    });
+  });
+
+  describe('getValidAccessToken', () => {
+    it('should return cached token if valid', async () => {
+      const tokens = {
+        access_token: 'test-token',
+        refresh_token: 'test-refresh-token',
+        expires_at: Date.now() + 3600000 // 1 hour from now
+      };
+      OAuthManager.saveTokens(tokens);
+      OAuthManager.cachedToken = 'test-token';
+
+      const token = await OAuthManager.getValidAccessToken();
+      expect(token).toBe('test-token');
+    });
+
+    it('should refresh token if expired', async () => {
+      const tokens = {
+        access_token: 'old-token',
+        refresh_token: 'test-refresh-token',
+        expires_at: Date.now() - 1000 // Expired
+      };
+      OAuthManager.saveTokens(tokens);
+
+      const mockResponse = {
+        access_token: 'new-token',
+        refresh_token: 'new-refresh-token',
+        expires_in: 3600
+      };
+
+      nock('https://console.anthropic.com')
+        .post('/v1/oauth/token')
+        .reply(200, mockResponse);
+
+      const token = await OAuthManager.getValidAccessToken();
+      expect(token).toBe('new-token');
+    });
+
+    it('should refresh token if expiring soon (within 1 minute)', async () => {
+      const tokens = {
+        access_token: 'old-token',
+        refresh_token: 'test-refresh-token',
+        expires_at: Date.now() + 30000 // 30 seconds from now
+      };
+      OAuthManager.saveTokens(tokens);
+
+      const mockResponse = {
+        access_token: 'new-token',
+        refresh_token: 'new-refresh-token',
+        expires_in: 3600
+      };
+
+      nock('https://console.anthropic.com')
+        .post('/v1/oauth/token')
+        .reply(200, mockResponse);
+
+      const token = await OAuthManager.getValidAccessToken();
+      expect(token).toBe('new-token');
+    });
+
+    it('should throw error if no tokens exist', async () => {
+      await expect(OAuthManager.getValidAccessToken()).rejects.toThrow(
+        'No authentication tokens found. Please authenticate first.'
+      );
+    });
+  });
+
+  describe('setRedirectURI', () => {
+    it('should set redirect URI', () => {
+      OAuthManager.setRedirectURI('http://example.com/callback');
+
+      const pkce = OAuthManager.generatePKCE();
+      const url = OAuthManager.buildAuthorizationURL(pkce);
+
+      expect(url).toContain('redirect_uri=http%3A%2F%2Fexample.com%2Fcallback');
+    });
+  });
+});

--- a/server/config.docker.txt
+++ b/server/config.docker.txt
@@ -1,0 +1,10 @@
+port=42069
+# Leave blank for auto-detect (127.0.0.1 native, 0.0.0.0 Docker)
+# Set explicitly to override: host=127.0.0.1 or host=0.0.0.0
+host=
+log_level=INFO  # TRACE, DEBUG, INFO, WARN, ERROR
+filter_sampling_params=true  # Set to true to ensure only one sampling parameter is sent (required for Sonnet 4.5 compatibility). Removes default values (1.0) and prefers temperature over top_p when both are non-default.
+
+# OAuth Settings
+auto_open_browser=false  # Disabled for Docker - browser auto-open doesn't work from containers
+fallback_to_claude_code=true  # Use Claude Code credentials as fallback

--- a/server/config.docker.txt
+++ b/server/config.docker.txt
@@ -8,3 +8,4 @@ filter_sampling_params=true  # Set to true to ensure only one sampling parameter
 # OAuth Settings
 auto_open_browser=false  # Disabled for Docker - browser auto-open doesn't work from containers
 fallback_to_claude_code=true  # Use Claude Code credentials as fallback
+oauth_flow=auto  # 'auto' = localhost callback (seamless), 'manual' = copy-paste code entry

--- a/server/config.docker.txt
+++ b/server/config.docker.txt
@@ -8,4 +8,3 @@ filter_sampling_params=true  # Set to true to ensure only one sampling parameter
 # OAuth Settings
 auto_open_browser=false  # Disabled for Docker - browser auto-open doesn't work from containers
 fallback_to_claude_code=true  # Use Claude Code credentials as fallback
-oauth_flow=auto  # 'auto' = localhost callback (seamless), 'manual' = copy-paste code entry

--- a/server/config.txt
+++ b/server/config.txt
@@ -1,4 +1,11 @@
 port=42069
-host=0.0.0.0
+# Leave blank for auto-detect (127.0.0.1 native, 0.0.0.0 Docker)
+# Set explicitly to override: host=127.0.0.1 or host=0.0.0.0
+host=
 log_level=INFO  # TRACE, DEBUG, INFO, WARN, ERROR
-filter_sampling_params=false  # Set to true to ensure only one sampling parameter is sent (required for Sonnet 4.5 compatibility). Removes default values (1.0) and prefers temperature over top_p when both are non-default.
+filter_sampling_params=true  # Set to true to ensure only one sampling parameter is sent (required for Sonnet 4.5 compatibility). Removes default values (1.0) and prefers temperature over top_p when both are non-default.
+
+# OAuth Settings
+auto_open_browser=true  # Open browser on first run if not authenticated
+fallback_to_claude_code=false  # Use Claude Code credentials as fallback
+oauth_flow=auto  # 'auto' = localhost callback (seamless), 'manual' = copy-paste code entry

--- a/server/config.txt
+++ b/server/config.txt
@@ -1,11 +1,4 @@
 port=42069
-# Leave blank for auto-detect (127.0.0.1 native, 0.0.0.0 Docker)
-# Set explicitly to override: host=127.0.0.1 or host=0.0.0.0
-host=
+host=0.0.0.0
 log_level=INFO  # TRACE, DEBUG, INFO, WARN, ERROR
-filter_sampling_params=true  # Set to true to ensure only one sampling parameter is sent (required for Sonnet 4.5 compatibility). Removes default values (1.0) and prefers temperature over top_p when both are non-default.
-
-# OAuth Settings
-auto_open_browser=true  # Open browser on first run if not authenticated
-fallback_to_claude_code=false  # Use Claude Code credentials as fallback
-oauth_flow=auto  # 'auto' = localhost callback (seamless), 'manual' = copy-paste code entry
+filter_sampling_params=false  # Set to true to ensure only one sampling parameter is sent (required for Sonnet 4.5 compatibility). Removes default values (1.0) and prefers temperature over top_p when both are non-default.

--- a/server/server.js
+++ b/server/server.js
@@ -4,8 +4,27 @@ const fs = require('fs');
 const path = require('path');
 const ClaudeRequest = require('./ClaudeRequest');
 const Logger = require('./Logger');
+const OAuthManager = require('./OAuthManager');
+const { exec } = require('child_process');
 
 let config = {};
+
+// PKCE state storage with automatic expiration (10 minutes)
+const pkceStates = new Map();
+const PKCE_EXPIRY_MS = 10 * 60 * 1000; // 10 minutes
+
+function cleanupExpiredPKCE() {
+  const now = Date.now();
+  for (const [state, data] of pkceStates.entries()) {
+    if (now - data.created_at > PKCE_EXPIRY_MS) {
+      pkceStates.delete(state);
+    }
+  }
+}
+
+// Cleanup expired PKCE states every minute
+setInterval(cleanupExpiredPKCE, 60000);
+
 function loadConfig() {
   try {
     const configPath = path.join(__dirname, 'config.txt');
@@ -49,28 +68,167 @@ function parseBody(req) {
 }
 
 function getClientIP(req) {
-  return req.headers['x-forwarded-for'] || 
-         req.headers['x-real-ip'] || 
-         req.connection.remoteAddress || 
+  return req.headers['x-forwarded-for'] ||
+         req.headers['x-real-ip'] ||
+         req.connection.remoteAddress ||
          '127.0.0.1';
+}
+
+function serveStaticFile(res, filePath, contentType) {
+  const staticPath = path.join(__dirname, 'static', filePath);
+  fs.readFile(staticPath, 'utf8', (err, data) => {
+    if (err) {
+      res.writeHead(404, { 'Content-Type': 'text/plain' });
+      res.end('Not found');
+      return;
+    }
+    res.writeHead(200, { 'Content-Type': contentType });
+    res.end(data);
+  });
+}
+
+function openBrowser(url) {
+  const command = process.platform === 'darwin' ? 'open' :
+                  process.platform === 'win32' ? 'start' :
+                  'xdg-open';
+
+  exec(`${command} "${url}"`, (error) => {
+    if (error) {
+      Logger.debug(`Failed to open browser: ${error.message}`);
+    }
+  });
+}
+
+function isRunningInDocker() {
+  // Check for /.dockerenv file (Docker creates this)
+  if (fs.existsSync('/.dockerenv')) return true;
+
+  // Check /proc/self/cgroup for docker/containerd (Linux)
+  try {
+    const cgroup = fs.readFileSync('/proc/self/cgroup', 'utf8');
+    return cgroup.includes('docker') || cgroup.includes('containerd');
+  } catch (err) {
+    return false;
+  }
 }
 
 async function handleRequest(req, res) {
   const clientIP = getClientIP(req);
-  const { pathname } = url.parse(req.url);
-  
+  const parsedUrl = url.parse(req.url, true);
+  const pathname = parsedUrl.pathname;
+
   Logger.info(`${req.method} ${pathname} from ${clientIP}`);
-  
+
   res.setHeader('Access-Control-Allow-Origin', '*');
   res.setHeader('Access-Control-Allow-Methods', 'GET, POST, PUT, DELETE, OPTIONS');
   res.setHeader('Access-Control-Allow-Headers', 'Content-Type, Authorization, X-Requested-With');
-  
+
   if (req.method === 'OPTIONS') {
     res.writeHead(200);
     res.end();
     return;
   }
-  
+
+  // OAuth Routes
+  if (pathname === '/auth/login' && req.method === 'GET') {
+    try {
+      const pkce = OAuthManager.generatePKCE();
+      pkceStates.set(pkce.state, {
+        code_verifier: pkce.code_verifier,
+        created_at: Date.now()
+      });
+
+      const authUrl = OAuthManager.buildAuthorizationURL(pkce);
+
+      res.writeHead(302, { 'Location': authUrl });
+      res.end();
+      Logger.info('Redirecting to OAuth authorization URL');
+    } catch (error) {
+      Logger.error('OAuth login error:', error.message);
+      res.writeHead(500, { 'Content-Type': 'application/json' });
+      res.end(JSON.stringify({ error: 'Failed to initiate OAuth login' }));
+    }
+    return;
+  }
+
+  if (pathname === '/auth/callback' && req.method === 'GET') {
+    try {
+      const query = parsedUrl.query;
+      const code = query.code;
+      const state = query.state;
+
+      if (!code || !state) {
+        throw new Error('Missing authorization code or state');
+      }
+
+      const pkceData = pkceStates.get(state);
+      if (!pkceData) {
+        throw new Error('Invalid or expired state parameter');
+      }
+
+      pkceStates.delete(state);
+
+      const tokens = await OAuthManager.exchangeCodeForTokens(code, pkceData.code_verifier);
+
+      const tokenData = {
+        access_token: tokens.access_token,
+        refresh_token: tokens.refresh_token,
+        expires_at: Date.now() + (tokens.expires_in * 1000)
+      };
+      OAuthManager.saveTokens(tokenData);
+
+      serveStaticFile(res, 'callback.html', 'text/html');
+      Logger.info('OAuth authentication successful');
+    } catch (error) {
+      Logger.error('OAuth callback error:', error.message);
+      res.writeHead(500, { 'Content-Type': 'text/html' });
+      res.end(`
+        <!DOCTYPE html>
+        <html>
+        <head><title>Authentication Failed</title></head>
+        <body>
+          <h1>Authentication Failed</h1>
+          <p>Error: ${error.message}</p>
+          <p><a href="/auth/login">Try again</a></p>
+        </body>
+        </html>
+      `);
+    }
+    return;
+  }
+
+  if (pathname === '/auth/status' && req.method === 'GET') {
+    try {
+      const isAuthenticated = OAuthManager.isAuthenticated();
+      const expiration = OAuthManager.getTokenExpiration();
+
+      res.writeHead(200, { 'Content-Type': 'application/json' });
+      res.end(JSON.stringify({
+        authenticated: isAuthenticated,
+        expires_at: expiration ? expiration.toISOString() : null
+      }));
+    } catch (error) {
+      Logger.error('Auth status error:', error.message);
+      res.writeHead(500, { 'Content-Type': 'application/json' });
+      res.end(JSON.stringify({ error: 'Failed to check authentication status' }));
+    }
+    return;
+  }
+
+  if (pathname === '/auth/logout' && req.method === 'GET') {
+    try {
+      OAuthManager.logout();
+      res.writeHead(200, { 'Content-Type': 'application/json' });
+      res.end(JSON.stringify({ success: true, message: 'Logged out successfully' }));
+      Logger.info('User logged out');
+    } catch (error) {
+      Logger.error('Logout error:', error.message);
+      res.writeHead(500, { 'Content-Type': 'application/json' });
+      res.end(JSON.stringify({ error: 'Failed to logout' }));
+    }
+    return;
+  }
+
   if (pathname === '/health') {
     res.writeHead(200, { 'Content-Type': 'application/json' });
     res.end(JSON.stringify({ status: 'ok', server: 'claude-code-proxy', timestamp: Date.now() }));
@@ -106,20 +264,48 @@ async function handleRequest(req, res) {
 
 function startServer() {
   loadConfig();
-  
+
   const server = http.createServer(handleRequest);
   const port = parseInt(config.port) || 3000;
-  const host = config.host || 'localhost';
-  
+
+  // Smart host binding: auto-detect Docker or use config
+  const host = config.host || (isRunningInDocker() ? '0.0.0.0' : '127.0.0.1');
+
   server.listen(port, host, () => {
     Logger.info(`claude-code-proxy server listening on ${host}:${port}`);
+
+    // Set the redirect URI for OAuth
+    const redirectUri = `http://localhost:${port}/auth/callback`;
+    OAuthManager.setRedirectURI(redirectUri);
+
+    // Display authentication status
+    const isAuthenticated = OAuthManager.isAuthenticated();
+    const expiration = OAuthManager.getTokenExpiration();
+
+    Logger.info('');
+    Logger.info('Authentication Status:');
+    if (isAuthenticated && expiration) {
+      Logger.info(`  ✓ Authenticated until ${expiration.toLocaleString()}`);
+    } else {
+      Logger.info('  ✗ Not authenticated');
+      const authUrl = `http://localhost:${port}/auth/login`;
+      Logger.info(`  → Visit ${authUrl} to authenticate`);
+
+      // Auto-open browser if configured
+      const autoOpenBrowser = config.auto_open_browser !== 'false';
+      if (!isAuthenticated && autoOpenBrowser) {
+        Logger.info('  → Opening browser for authentication...');
+        setTimeout(() => openBrowser(authUrl), 1000);
+      }
+    }
+    Logger.info('');
   });
-  
+
   process.on('SIGTERM', () => {
     Logger.info('Shutting down...');
     server.close(() => process.exit(0));
   });
-  
+
   process.on('SIGINT', () => {
     Logger.info('Shutting down...');
     server.close(() => process.exit(0));

--- a/server/server.js
+++ b/server/server.js
@@ -302,9 +302,9 @@ function startServer() {
       const authUrl = `http://localhost:${port}/auth/login`;
       Logger.info(`  → Visit ${authUrl} to authenticate`);
 
-      // Auto-open browser if configured
+      // Auto-open browser if configured (only works when running natively)
       const autoOpenBrowser = config.auto_open_browser !== 'false';
-      if (!isAuthenticated && autoOpenBrowser) {
+      if (!isAuthenticated && autoOpenBrowser && !isRunningInDocker()) {
         Logger.info('  → Opening browser for authentication...');
         setTimeout(() => openBrowser(authUrl), 1000);
       }

--- a/server/server.js
+++ b/server/server.js
@@ -131,7 +131,30 @@ async function handleRequest(req, res) {
 
   // OAuth Routes
   if (pathname === '/auth/login' && req.method === 'GET') {
-    serveStaticFile(res, 'login.html', 'text/html');
+    // Check if using auto flow - redirect directly to OAuth
+    const isAutoFlow = OAuthManager.getRedirectURI().includes('localhost');
+
+    if (isAutoFlow) {
+      try {
+        const pkce = OAuthManager.generatePKCE();
+        pkceStates.set(pkce.state, {
+          code_verifier: pkce.code_verifier,
+          created_at: Date.now()
+        });
+
+        const authUrl = OAuthManager.buildAuthorizationURL(pkce);
+        res.writeHead(302, { 'Location': authUrl });
+        res.end();
+        Logger.info('Redirecting to OAuth authorization (auto flow)');
+      } catch (error) {
+        Logger.error('OAuth login redirect error:', error.message);
+        res.writeHead(500, { 'Content-Type': 'text/plain' });
+        res.end('Failed to initiate OAuth login');
+      }
+    } else {
+      // Manual flow - serve the login page
+      serveStaticFile(res, 'login.html', 'text/html');
+    }
     return;
   }
 
@@ -144,9 +167,10 @@ async function handleRequest(req, res) {
       });
 
       const authUrl = OAuthManager.buildAuthorizationURL(pkce);
+      const isAutoFlow = OAuthManager.getRedirectURI().includes('localhost');
 
       res.writeHead(200, { 'Content-Type': 'application/json' });
-      res.end(JSON.stringify({ url: authUrl, state: pkce.state }));
+      res.end(JSON.stringify({ url: authUrl, state: pkce.state, flow: isAutoFlow ? 'auto' : 'manual' }));
       Logger.info('Generated OAuth authorization URL');
     } catch (error) {
       Logger.error('OAuth get-url error:', error.message);
@@ -285,6 +309,16 @@ function startServer() {
 
   // Smart host binding: auto-detect Docker or use config
   const host = config.host || (isRunningInDocker() ? '0.0.0.0' : '127.0.0.1');
+
+  // Configure OAuth flow based on config
+  const oauthFlow = config.oauth_flow || 'auto';
+  if (oauthFlow === 'auto') {
+    OAuthManager.setRedirectURI(`http://localhost:${port}/auth/callback`);
+    Logger.info(`OAuth flow: auto (localhost callback)`);
+  } else {
+    OAuthManager.setRedirectURI('manual');
+    Logger.info(`OAuth flow: manual (copy-paste code entry)`);
+  }
 
   server.listen(port, host, () => {
     Logger.info(`claude-code-proxy server listening on ${host}:${port}`);

--- a/server/server.js
+++ b/server/server.js
@@ -183,7 +183,7 @@ async function handleRequest(req, res) {
 
       pkceStates.delete(state);
 
-      const tokens = await OAuthManager.exchangeCodeForTokens(code, pkceData.code_verifier);
+      const tokens = await OAuthManager.exchangeCodeForTokens(code, pkceData.code_verifier, state);
 
       const tokenData = {
         access_token: tokens.access_token,

--- a/server/server.test.js
+++ b/server/server.test.js
@@ -66,9 +66,6 @@ describe('OAuth Routes Integration Tests', () => {
       fs.rmSync(testDir, { recursive: true, force: true });
     }
 
-    // Set redirect URI for tests
-    OAuthManager.setRedirectURI('http://localhost:42069/auth/callback');
-
     // Initialize PKCE states map
     pkceStates = new Map();
 

--- a/server/server.test.js
+++ b/server/server.test.js
@@ -1,0 +1,405 @@
+const request = require('supertest');
+const http = require('http');
+const fs = require('fs');
+const path = require('path');
+const nock = require('nock');
+
+// Mock Logger before requiring server
+jest.mock('./Logger', () => ({
+  info: jest.fn(),
+  debug: jest.fn(),
+  error: jest.fn(),
+  warn: jest.fn(),
+  init: jest.fn(),
+  getLogLevel: jest.fn().mockReturnValue(0)
+}));
+
+const OAuthManager = require('./OAuthManager');
+
+// Import server components after mocking
+const url = require('url');
+const parseBody = (req) => {
+  return new Promise((resolve, reject) => {
+    let body = '';
+    req.on('data', chunk => {
+      body += chunk.toString();
+    });
+    req.on('end', () => {
+      try {
+        resolve(body ? JSON.parse(body) : {});
+      } catch (error) {
+        reject(new Error(`Invalid JSON: ${error.message}`));
+      }
+    });
+    req.on('error', reject);
+  });
+};
+
+describe('OAuth Routes Integration Tests', () => {
+  let server;
+  let testTokenPath;
+  let pkceStates;
+
+  beforeAll(() => {
+    // Mock the config file
+    const configPath = path.join(__dirname, 'config.txt');
+    const originalReadFileSync = fs.readFileSync;
+
+    jest.spyOn(fs, 'readFileSync').mockImplementation((filePath, encoding) => {
+      if (filePath === configPath) {
+        return 'port=42069\nhost=\nlog_level=INFO\nauto_open_browser=false\nfallback_to_claude_code=false';
+      }
+      return originalReadFileSync(filePath, encoding);
+    });
+  });
+
+  beforeEach(() => {
+    // Use a temporary directory for testing
+    testTokenPath = path.join(__dirname, '.test-tokens-integration', 'tokens.json');
+    OAuthManager.tokenPath = testTokenPath;
+    OAuthManager.cachedToken = null;
+    OAuthManager.refreshPromise = null;
+
+    // Clean up test directory
+    const testDir = path.dirname(testTokenPath);
+    if (fs.existsSync(testDir)) {
+      fs.rmSync(testDir, { recursive: true, force: true });
+    }
+
+    // Set redirect URI for tests
+    OAuthManager.setRedirectURI('http://localhost:42069/auth/callback');
+
+    // Initialize PKCE states map
+    pkceStates = new Map();
+
+    // Create test server with OAuth routes
+    const handleRequest = async (req, res) => {
+      const parsedUrl = url.parse(req.url, true);
+      const pathname = parsedUrl.pathname;
+
+      res.setHeader('Access-Control-Allow-Origin', '*');
+      res.setHeader('Access-Control-Allow-Methods', 'GET, POST, PUT, DELETE, OPTIONS');
+      res.setHeader('Access-Control-Allow-Headers', 'Content-Type, Authorization, X-Requested-With');
+
+      if (req.method === 'OPTIONS') {
+        res.writeHead(200);
+        res.end();
+        return;
+      }
+
+      // OAuth Routes
+      if (pathname === '/auth/login' && req.method === 'GET') {
+        try {
+          const pkce = OAuthManager.generatePKCE();
+          pkceStates.set(pkce.state, {
+            code_verifier: pkce.code_verifier,
+            created_at: Date.now()
+          });
+
+          const authUrl = OAuthManager.buildAuthorizationURL(pkce);
+          res.writeHead(302, { 'Location': authUrl });
+          res.end();
+        } catch (error) {
+          res.writeHead(500, { 'Content-Type': 'application/json' });
+          res.end(JSON.stringify({ error: 'Failed to initiate OAuth login' }));
+        }
+        return;
+      }
+
+      if (pathname === '/auth/callback' && req.method === 'GET') {
+        try {
+          const query = parsedUrl.query;
+          const code = query.code;
+          const state = query.state;
+
+          if (!code || !state) {
+            throw new Error('Missing authorization code or state');
+          }
+
+          const pkceData = pkceStates.get(state);
+          if (!pkceData) {
+            throw new Error('Invalid or expired state parameter');
+          }
+
+          pkceStates.delete(state);
+
+          const tokens = await OAuthManager.exchangeCodeForTokens(code, pkceData.code_verifier);
+
+          const tokenData = {
+            access_token: tokens.access_token,
+            refresh_token: tokens.refresh_token,
+            expires_at: Date.now() + (tokens.expires_in * 1000)
+          };
+          OAuthManager.saveTokens(tokenData);
+
+          res.writeHead(200, { 'Content-Type': 'text/html' });
+          res.end('<html><body><h1>Authentication Successful!</h1></body></html>');
+        } catch (error) {
+          res.writeHead(500, { 'Content-Type': 'text/html' });
+          res.end(`
+            <!DOCTYPE html>
+            <html>
+            <head><title>Authentication Failed</title></head>
+            <body>
+              <h1>Authentication Failed</h1>
+              <p>Error: ${error.message}</p>
+            </body>
+            </html>
+          `);
+        }
+        return;
+      }
+
+      if (pathname === '/auth/status' && req.method === 'GET') {
+        try {
+          const isAuthenticated = OAuthManager.isAuthenticated();
+          const expiration = OAuthManager.getTokenExpiration();
+
+          res.writeHead(200, { 'Content-Type': 'application/json' });
+          res.end(JSON.stringify({
+            authenticated: isAuthenticated,
+            expires_at: expiration ? expiration.toISOString() : null
+          }));
+        } catch (error) {
+          res.writeHead(500, { 'Content-Type': 'application/json' });
+          res.end(JSON.stringify({ error: 'Failed to check authentication status' }));
+        }
+        return;
+      }
+
+      if (pathname === '/auth/logout' && req.method === 'GET') {
+        try {
+          OAuthManager.logout();
+          res.writeHead(200, { 'Content-Type': 'application/json' });
+          res.end(JSON.stringify({ success: true, message: 'Logged out successfully' }));
+        } catch (error) {
+          res.writeHead(500, { 'Content-Type': 'application/json' });
+          res.end(JSON.stringify({ error: 'Failed to logout' }));
+        }
+        return;
+      }
+
+      res.writeHead(404, { 'Content-Type': 'application/json' });
+      res.end(JSON.stringify({ error: 'Not found' }));
+    };
+
+    server = http.createServer(handleRequest);
+
+    // Start server on a random port for testing
+    return new Promise((resolve) => {
+      server.listen(0, '127.0.0.1', () => {
+        resolve();
+      });
+    });
+  });
+
+  afterEach((done) => {
+    // Clean up
+    const testDir = path.dirname(testTokenPath);
+    if (fs.existsSync(testDir)) {
+      fs.rmSync(testDir, { recursive: true, force: true });
+    }
+    nock.cleanAll();
+
+    if (server) {
+      server.close(done);
+    } else {
+      done();
+    }
+  });
+
+  afterAll(() => {
+    jest.restoreAllMocks();
+  });
+
+  describe('GET /auth/login', () => {
+    it('should redirect to OAuth authorization URL', async () => {
+      const response = await request(server).get('/auth/login');
+
+      expect(response.status).toBe(302);
+      expect(response.headers.location).toContain('https://claude.ai/oauth/authorize');
+      expect(response.headers.location).toContain('client_id=9d1c250a-e61b-44d9-88ed-5944d1962f5e');
+      expect(response.headers.location).toContain('response_type=code');
+      expect(response.headers.location).toContain('code_challenge=');
+      expect(response.headers.location).toContain('code_challenge_method=S256');
+      expect(response.headers.location).toContain('state=');
+    });
+
+    it('should store PKCE state for callback verification', async () => {
+      const response = await request(server).get('/auth/login');
+
+      const locationUrl = new URL(response.headers.location);
+      const state = locationUrl.searchParams.get('state');
+
+      expect(pkceStates.has(state)).toBe(true);
+      expect(pkceStates.get(state)).toHaveProperty('code_verifier');
+      expect(pkceStates.get(state)).toHaveProperty('created_at');
+    });
+  });
+
+  describe('GET /auth/callback', () => {
+    it('should exchange code for tokens and save them', async () => {
+      // First, initiate login to get state
+      const loginResponse = await request(server).get('/auth/login');
+      const locationUrl = new URL(loginResponse.headers.location);
+      const state = locationUrl.searchParams.get('state');
+
+      // Mock the token exchange
+      const mockTokens = {
+        access_token: 'mock-access-token',
+        refresh_token: 'mock-refresh-token',
+        expires_in: 3600
+      };
+
+      nock('https://console.anthropic.com')
+        .post('/v1/oauth/token')
+        .reply(200, mockTokens);
+
+      // Make callback request
+      const response = await request(server)
+        .get(`/auth/callback?code=test-code&state=${state}`);
+
+      expect(response.status).toBe(200);
+      expect(response.text).toContain('Authentication Successful');
+
+      // Verify tokens were saved
+      const savedTokens = OAuthManager.loadTokens();
+      expect(savedTokens).toBeTruthy();
+      expect(savedTokens.access_token).toBe('mock-access-token');
+      expect(savedTokens.refresh_token).toBe('mock-refresh-token');
+    });
+
+    it('should return error if code is missing', async () => {
+      const response = await request(server)
+        .get('/auth/callback?state=test-state');
+
+      expect(response.status).toBe(500);
+      expect(response.text).toContain('Authentication Failed');
+      expect(response.text).toContain('Missing authorization code or state');
+    });
+
+    it('should return error if state is missing', async () => {
+      const response = await request(server)
+        .get('/auth/callback?code=test-code');
+
+      expect(response.status).toBe(500);
+      expect(response.text).toContain('Authentication Failed');
+      expect(response.text).toContain('Missing authorization code or state');
+    });
+
+    it('should return error if state is invalid', async () => {
+      const response = await request(server)
+        .get('/auth/callback?code=test-code&state=invalid-state');
+
+      expect(response.status).toBe(500);
+      expect(response.text).toContain('Authentication Failed');
+      expect(response.text).toContain('Invalid or expired state parameter');
+    });
+
+    it('should delete state after successful callback', async () => {
+      // First, initiate login to get state
+      const loginResponse = await request(server).get('/auth/login');
+      const locationUrl = new URL(loginResponse.headers.location);
+      const state = locationUrl.searchParams.get('state');
+
+      expect(pkceStates.has(state)).toBe(true);
+
+      // Mock the token exchange
+      const mockTokens = {
+        access_token: 'mock-access-token',
+        refresh_token: 'mock-refresh-token',
+        expires_in: 3600
+      };
+
+      nock('https://console.anthropic.com')
+        .post('/v1/oauth/token')
+        .reply(200, mockTokens);
+
+      // Make callback request
+      await request(server)
+        .get(`/auth/callback?code=test-code&state=${state}`);
+
+      // State should be deleted
+      expect(pkceStates.has(state)).toBe(false);
+    });
+  });
+
+  describe('GET /auth/status', () => {
+    it('should return not authenticated when no tokens exist', async () => {
+      const response = await request(server).get('/auth/status');
+
+      expect(response.status).toBe(200);
+      expect(response.body).toEqual({
+        authenticated: false,
+        expires_at: null
+      });
+    });
+
+    it('should return authenticated when tokens exist', async () => {
+      const expiresAt = Date.now() + 3600000;
+      const tokens = {
+        access_token: 'test-token',
+        refresh_token: 'test-refresh-token',
+        expires_at: expiresAt
+      };
+      OAuthManager.saveTokens(tokens);
+
+      const response = await request(server).get('/auth/status');
+
+      expect(response.status).toBe(200);
+      expect(response.body.authenticated).toBe(true);
+      expect(response.body.expires_at).toBeTruthy();
+    });
+  });
+
+  describe('GET /auth/logout', () => {
+    it('should delete tokens and return success', async () => {
+      // Save some tokens first
+      const tokens = {
+        access_token: 'test-token',
+        refresh_token: 'test-refresh-token',
+        expires_at: Date.now() + 3600000
+      };
+      OAuthManager.saveTokens(tokens);
+
+      expect(OAuthManager.isAuthenticated()).toBe(true);
+
+      const response = await request(server).get('/auth/logout');
+
+      expect(response.status).toBe(200);
+      expect(response.body).toEqual({
+        success: true,
+        message: 'Logged out successfully'
+      });
+
+      expect(OAuthManager.isAuthenticated()).toBe(false);
+    });
+
+    it('should succeed even if no tokens exist', async () => {
+      const response = await request(server).get('/auth/logout');
+
+      expect(response.status).toBe(200);
+      expect(response.body).toEqual({
+        success: true,
+        message: 'Logged out successfully'
+      });
+    });
+  });
+
+  describe('CORS headers', () => {
+    it('should include CORS headers in all responses', async () => {
+      const response = await request(server).get('/auth/status');
+
+      expect(response.headers['access-control-allow-origin']).toBe('*');
+      expect(response.headers['access-control-allow-methods']).toBe('GET, POST, PUT, DELETE, OPTIONS');
+      expect(response.headers['access-control-allow-headers']).toBe('Content-Type, Authorization, X-Requested-With');
+    });
+
+    it('should handle OPTIONS requests', async () => {
+      const response = await request(server).options('/auth/status');
+
+      expect(response.status).toBe(200);
+      expect(response.headers['access-control-allow-origin']).toBe('*');
+    });
+  });
+});

--- a/server/static/callback.html
+++ b/server/static/callback.html
@@ -1,0 +1,76 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Authentication Successful</title>
+  <style>
+    body {
+      font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif;
+      max-width: 600px;
+      margin: 100px auto;
+      padding: 20px;
+      text-align: center;
+      background-color: #f5f5f5;
+    }
+    .container {
+      background: white;
+      border-radius: 8px;
+      padding: 40px;
+      box-shadow: 0 2px 10px rgba(0,0,0,0.1);
+    }
+    h1 {
+      color: #2d3748;
+      margin-bottom: 20px;
+    }
+    .success-icon {
+      font-size: 64px;
+      margin-bottom: 20px;
+    }
+    p {
+      color: #4a5568;
+      line-height: 1.6;
+      margin-bottom: 20px;
+    }
+    .info-box {
+      background-color: #e6f7ff;
+      border: 1px solid #91d5ff;
+      border-radius: 4px;
+      padding: 16px;
+      margin: 20px 0;
+      text-align: left;
+    }
+    .info-box strong {
+      color: #1890ff;
+    }
+    code {
+      background-color: #f0f0f0;
+      padding: 2px 6px;
+      border-radius: 3px;
+      font-family: 'Courier New', monospace;
+    }
+  </style>
+</head>
+<body>
+  <div class="container">
+    <div class="success-icon">✓</div>
+    <h1>Authentication Successful!</h1>
+    <p>You have successfully authenticated with Claude MAX.</p>
+
+    <div class="info-box">
+      <strong>Next Steps:</strong>
+      <ul style="text-align: left; margin: 10px 0 0 0;">
+        <li>Your access token has been saved locally</li>
+        <li>The token will be automatically refreshed when needed</li>
+        <li>You can now use the claude-code-proxy API</li>
+      </ul>
+    </div>
+
+    <p>You can safely close this window and return to your terminal.</p>
+
+    <p style="font-size: 14px; color: #718096; margin-top: 30px;">
+      Token stored in: <code>~/.claude-code-proxy/tokens.json</code>
+    </p>
+  </div>
+</body>
+</html>

--- a/server/static/login.html
+++ b/server/static/login.html
@@ -1,0 +1,133 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Authenticate with Claude</title>
+  <style>
+    body {
+      font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif;
+      max-width: 700px;
+      margin: 100px auto;
+      padding: 20px;
+      background-color: #f5f5f5;
+    }
+    .container {
+      background: white;
+      border-radius: 8px;
+      padding: 40px;
+      box-shadow: 0 2px 10px rgba(0,0,0,0.1);
+    }
+    h1 {
+      color: #2d3748;
+      margin-bottom: 20px;
+    }
+    .step {
+      background-color: #f0f7ff;
+      border-left: 4px solid #1890ff;
+      padding: 15px;
+      margin: 20px 0;
+    }
+    .step strong {
+      color: #1890ff;
+      display: block;
+      margin-bottom: 10px;
+    }
+    .button {
+      background-color: #1890ff;
+      color: white;
+      padding: 12px 24px;
+      border: none;
+      border-radius: 4px;
+      font-size: 16px;
+      cursor: pointer;
+      text-decoration: none;
+      display: inline-block;
+      margin: 10px 0;
+    }
+    .button:hover {
+      background-color: #0066cc;
+    }
+    input[type="text"] {
+      width: 100%;
+      padding: 12px;
+      border: 1px solid #d9d9d9;
+      border-radius: 4px;
+      font-size: 14px;
+      font-family: 'Courier New', monospace;
+      margin: 10px 0;
+      box-sizing: border-box;
+    }
+    .form-group {
+      margin: 20px 0;
+    }
+    label {
+      display: block;
+      margin-bottom: 8px;
+      font-weight: 500;
+      color: #2d3748;
+    }
+    .warning {
+      background-color: #fff7e6;
+      border-left: 4px solid #ffa940;
+      padding: 12px;
+      margin: 15px 0;
+      color: #ad6800;
+    }
+  </style>
+</head>
+<body>
+  <div class="container">
+    <h1>Authenticate with Claude MAX</h1>
+
+    <div class="step">
+      <strong>Step 1:</strong>
+      Click the button below to open the Claude authorization page
+    </div>
+
+    <a href="#" class="button" id="authButton">Open Authorization Page</a>
+
+    <div class="step">
+      <strong>Step 2:</strong>
+      After authorizing, you'll see an authorization code on the page. Copy it.
+    </div>
+
+    <div class="warning">
+      <strong>Note:</strong> The code format is <code>code#state</code> - copy the entire string including the # symbol.
+    </div>
+
+    <div class="step">
+      <strong>Step 3:</strong>
+      Paste the code below and submit
+    </div>
+
+    <form action="/auth/callback" method="GET">
+      <div class="form-group">
+        <label for="codeInput">Authorization Code:</label>
+        <input
+          type="text"
+          id="codeInput"
+          name="manual_code"
+          placeholder="Paste code#state here"
+          required
+        >
+      </div>
+      <button type="submit" class="button">Submit Code</button>
+    </form>
+  </div>
+
+  <script>
+    document.getElementById('authButton').addEventListener('click', async function(e) {
+      e.preventDefault();
+
+      // Get the auth URL from the server
+      const response = await fetch('/auth/get-url');
+      const data = await response.json();
+
+      if (data.url) {
+        window.open(data.url, '_blank');
+      }
+    });
+  </script>
+</body>
+</html>


### PR DESCRIPTION
# Add OAuth Authentication Support

This PR adds standalone OAuth authentication to claude-code-proxy, allowing users to authenticate without needing Claude Code installed locally.

## Changes

- Implements complete OAuth flow with PKCE support matching Anthropic's requirements
- Adds manual code entry OAuth method for seamless authentication
- Supports native Claude Code installer as optional fallback

## User Benefit

Users can now set up and use claude-code-proxy with just OAuth credentials, eliminating the dependency on having Claude Code available on their system.