### PR TITLE
Skip magic words system prompt injection for Haiku models

### DIFF
--- a/server/ClaudeRequest.js
+++ b/server/ClaudeRequest.js
@@ -333,19 +333,26 @@ class ClaudeRequest {
   processRequestBody(body, presetName = null) {
     if (!body) return body;
 
-    const systemPrompt = {
-      type: 'text',
-      text: 'You are Claude Code, Anthropic\'s official CLI for Claude.'
-    };
+    // Skip system prompt injection for Haiku models
+    const isHaiku = body.model && body.model.toLowerCase().includes('haiku');
 
-    if (body.system) {
-      if (Array.isArray(body.system)) {
-        body.system.unshift(systemPrompt);
+    if (!isHaiku) {
+      const systemPrompt = {
+        type: 'text',
+        text: 'You are Claude Code, Anthropic\'s official CLI for Claude.'
+      };
+
+      if (body.system) {
+        if (Array.isArray(body.system)) {
+          body.system.unshift(systemPrompt);
+        } else {
+          body.system = [systemPrompt, { type: 'text', text: body.system }];
+        }
       } else {
-        body.system = [systemPrompt, body.system];
+        body.system = [systemPrompt];
       }
     } else {
-      body.system = [systemPrompt];
+      Logger.debug('Skipping Claude Code system prompt for Haiku model');
     }
 
     if (presetName) {


### PR DESCRIPTION
## Problem
Haiku models don't actually require the "You are Claude Code..." system prompt to be authenticated by the API endpoint so it's just unnecessarily confusing the model.

## Solution
Detect Haiku models (case-insensitive check for "haiku" in model name) and skip the system prompt injection for those models only.