### PR TITLE
Add TypingMind compatibility and PHI support

### DIFF
--- a/server/server.js
+++ b/server/server.js
@@ -127,7 +127,7 @@ async function handleRequest(req, res) {
 
   res.setHeader('Access-Control-Allow-Origin', '*');
   res.setHeader('Access-Control-Allow-Methods', 'GET, POST, PUT, DELETE, OPTIONS');
-  res.setHeader('Access-Control-Allow-Headers', 'Content-Type, Authorization, X-Requested-With');
+  res.setHeader('Access-Control-Allow-Headers', 'Content-Type, Authorization, X-Requested-With, anthropic-version, anthropic-beta, x-api-key');
 
   if (req.method === 'OPTIONS') {
     res.writeHead(200);


### PR DESCRIPTION
## Summary
Adds TypingMind compatibility, web search/fetch capability, and PHI (Post History Instruction) support for clients without native PHI support.

## Changes
- **TypingMind setup guide** - Documents full endpoint URL requirement (`/v1/messages`)
- **PHI injection** - Accepts `phi` or `PHI` field in request body, injects as user message after last user message, then strips before forwarding to Claude API
- **CORS headers** - Added `anthropic-version`, `anthropic-beta`, `x-api-key` to allowed headers
- **Fixes system prompt handling** when client (like TypingMind!) sends string instead of array 
- **Web tools support** - Added `web-search-2025-03-05` and `web-fetch-2025-09-10` beta headers to enable "Web Browser" toggle switch to work in TypingMind

## Need for Post History Injection (PHI) support
Unlike SillyTavern, clients like TypingMind don't have native PHI support. This allows users to send ephemeral per-request instructions (reply rules, formatting preferences) that aren't stored in conversation history, as long as the client (TypingMind does!) supports custom body elements. To use this function, just have the client send a custom body element "phi" with the desired PHI.
