### PR TITLE
Fix: wrap string system prompts as text block objects

### DIFF
--- a/server/ClaudeRequest.js
+++ b/server/ClaudeRequest.js
@@ -342,7 +342,7 @@ class ClaudeRequest {
       if (Array.isArray(body.system)) {
         body.system.unshift(systemPrompt);
       } else {
-        body.system = [systemPrompt, body.system];
+        body.system = typeof body.system === 'string' ? [systemPrompt, { type: 'text', text: body.system }] : [systemPrompt, body.system];
       }
     } else {
       body.system = [systemPrompt];


### PR DESCRIPTION
The Anthropic API expects system array items to be objects with `type` and `text` fields, not raw strings.

## Problem
When a client sends the system prompt as a plain string rather than an array of content blocks, the proxy previously created an invalid array like:
```js
[systemPrompt, "user string here"]
```

This causes Anthropic API errors since the second element is a raw string instead of a content block object.

## Solution
Now properly wraps string system prompts:
```js
[systemPrompt, { type: "text", text: "user string here" }]
```

## Testing
Tested with Graphiti (knowledge graph library) which sends string system prompts.